### PR TITLE
scripts/template_verifier.py: Use argparse instead of optparse, set d…

### DIFF
--- a/indra/newview/ascentprefsvan.cpp
+++ b/indra/newview/ascentprefsvan.cpp
@@ -68,6 +68,10 @@ LLPrefsAscentVan::LLPrefsAscentVan()
 	getChild<LLUICtrl>("update_clientdefs")->setCommitCallback(boost::bind(LLPrefsAscentVan::onManualClientUpdate));
     getChild<LLUICtrl>("custom_avatar_name_color")->setCommitCallback(boost::bind(&LLPrefsAscentVan::onAvatarNameColor, this, _1));
     getChild<LLUICtrl>("show_avatar_distance")->setCommitCallback(boost::bind(&LLPrefsAscentVan::onAvatarDistance, this, _1));
+
+    mGenesisShowOnlineNotificationChiclet = gSavedSettings.getBOOL("GenesisShowOnlineNotificationChiclet");
+    mEnableAORemote = gSavedSettings.getBOOL("EnableAORemote");
+
     mShowToolBar = gSavedSettings.getBOOL("ShowToolBar");
     mUiToolTipDelay = gSavedSettings.getF32("ToolTipDelay");
     mSLBShowFPS = gSavedSettings.getBOOL("SLBShowFPS");
@@ -187,6 +191,8 @@ void LLPrefsAscentVan::refreshValues()
 	mConnectToNeighbors = gSavedSettings.getBOOL("AlchemyConnectToNeighbors");
 	mRestartMinimized		= gSavedSettings.getBOOL("LiruRegionRestartMinimized");
 	mRestartSound			= gSavedSettings.getString("UISndRestart");
+    mGenesisShowOnlineNotificationChiclet = gSavedSettings.getBOOL("GenesisShowOnlineNotificationChiclet");
+    mEnableAORemote         = gSavedSettings.getBOOL("EnableAORemote");
 
     //Tags\Colors ----------------------------------------------------------------------------
     mAscentBroadcastTag     = gSavedSettings.getBOOL("AscentBroadcastTag");
@@ -291,6 +297,8 @@ void LLPrefsAscentVan::cancel()
 	gSavedSettings.setBOOL("AlchemyConnectToNeighbors",     mConnectToNeighbors);
 	gSavedSettings.setBOOL("LiruRegionRestartMinimized", mRestartMinimized);
 	gSavedSettings.setString("UISndRestart", mRestartSound);
+    gSavedSettings.setBOOL("GenesisShowOnlineNotificationChiclet", mGenesisShowOnlineNotificationChiclet);
+    gSavedSettings.setBOOL("EnableAORemote", mEnableAORemote);
 
     //Tags\Colors ----------------------------------------------------------------------------
     gSavedSettings.setBOOL("AscentBroadcastTag",         mAscentBroadcastTag);

--- a/indra/newview/ascentprefsvan.h
+++ b/indra/newview/ascentprefsvan.h
@@ -65,6 +65,8 @@ private:
 	bool mAnnounceStreamMetadata;
 	F32 mInactiveFloaterTransparency, mActiveFloaterTransparency;
 	S32  mBackgroundYieldTime;
+	bool mGenesisShowOnlineNotificationChiclet;
+	bool mEnableAORemote;
 	bool mScriptErrorsStealFocus;
 	bool mConnectToNeighbors;
 	bool mRestartMinimized;

--- a/indra/newview/genxdroptarget.cpp
+++ b/indra/newview/genxdroptarget.cpp
@@ -87,6 +87,7 @@ void GenxDropTarget::initFromXML(LLXMLNodePtr node, LLView* parent)
 		std::string label;
 		node->getAttributeString("label", label);
 		mText->setText(label);
+		mLabel=label;
 	}
 
 	if (node->hasAttribute("fill_parent"))
@@ -145,6 +146,7 @@ void GenxDropTarget::setValue(const LLSD& value)
 {
 	const LLUUID& id(value.asUUID());
 	setItem(id.isNull() ? NULL : gInventory.getItem(id));
+	
 }
 
 void GenxDropTarget::setItem(LLInventoryItem* item)
@@ -153,7 +155,7 @@ void GenxDropTarget::setItem(LLInventoryItem* item)
 	if (item) 
 		mText->setText(item->getName());
 	else	
-		mText->setText(std::string(""));
+		mText->setText(mLabel);
 	this->mItem=item;	
 }
 

--- a/indra/newview/genxdroptarget.h
+++ b/indra/newview/genxdroptarget.h
@@ -57,6 +57,8 @@ protected:
 	class LLButton* mReset;
 	class LLUICtrl* mCtrl;
 	//LLUICtrl::commit_signal_t*		mCommitSignal;
+private: 
+	std::string mLabel;	
 };
 
 #endif // GENXDROPTARGET_H

--- a/indra/newview/genxfloaterao.cpp
+++ b/indra/newview/genxfloaterao.cpp
@@ -304,8 +304,7 @@ void GenxFloaterAO::onSelectAOSet()
         getChild<LLButton>("viewcard")->setVisible(true);
         getChild<LLButton>("reload")->setVisible(true);
         getChild<LLButton>("newcard")->setVisible(false);
-        
-        AOSystem::instance().initSingleton();
+        (gSavedSettings.getBOOL("AOEnabled")) ? AOSystem::instance().initSingleton():AOSystem::requestConfigNotecard(false);
         
     } else {
         getChild<GenxDropTarget>("ao_notecard")->setValue(LLUUID());
@@ -334,7 +333,7 @@ void GenxFloaterAO::onSelectAOSet()
                 gSavedPerAccountSettings.setString(mapCombosToControlNames[defaultanim_iter.first],defaultanim_iter.second);
             }    
         }  
-        AOSystem::instance().initSingleton();
+        (gSavedSettings.getBOOL("AOEnabled")) ? AOSystem::instance().initSingleton():AOSystem::requestConfigNotecard(false);
         
     }
     

--- a/indra/newview/skins/default/xui/en-us/panel_preferences_ascent_vanity.xml
+++ b/indra/newview/skins/default/xui/en-us/panel_preferences_ascent_vanity.xml
@@ -22,6 +22,7 @@
 
       <slider bottom_delta="-20" left_delta="-222" follows="top" control_name="BackgroundYieldTime"  increment="1" label="Background Yield Time:" label_width="150" max_val="200" min_val="10" name="BackgroundYieldTime" show_text="true" width="400" tool_tip="A higher value will release more CPU time when the viewer is not in focus.  Setting this option too high on slower computers could cause the viewer to stall"/>
       <check_box bottom_delta="-25" follows="top" label="Show friends online/offline chiclet indicators" name="online_offline_indicators" control_name="GenesisShowOnlineNotificationChiclet" tool_tip="Display or not a notification on bottom right when friend comes offline/online"/>
+      <check_box bottom_delta="-20" follows="top" label="Use the built-in AO" name="EnableAORemote" control_name="EnableAORemote" tool_tip="Enable the built-in AO on/off button"/>
     </panel>
     <panel border="true" left="1" bottom="-190" height="180" width="600" label="Tags/Colors" name="TagsColors">
       <!-- Client tag options -->

--- a/indra/newview/skins/default/xui/fr/panel_overlaybar.xml
+++ b/indra/newview/skins/default/xui/fr/panel_overlaybar.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <panel name="overlay">
 	<layout_stack name="overlay_layout_panel">
-		<layout_panel min_width="410" name="main_panel" width="410">
-			<layout_stack name="chatbar_and_buttons" right="410">
-				<layout_panel name="padding" width="410"/>
-				<layout_panel name="state_management_buttons_container" width="410">
+		<layout_panel min_width="420" name="main_panel" width="420">
+			<layout_stack name="chatbar_and_buttons" right="420">
+				<layout_panel name="padding" width="420"/>
+				<layout_panel name="state_management_buttons_container" width="420">
 					
 					<button label="Disponible" label_selected="Disponible" name="Set Not Busy" tool_tip="Le chat et les IM ne s&apos;affichent pas. Cliquez ici pour ne plus être en mode occupé(e)."/>
 					<button label="Flycam" label_selected="Flycam" name="Flycam" tool_tip="Votre caméra est contrôlée par le joystick, cliquez ici pour la libérer."/>
@@ -20,7 +20,8 @@
         </layout_panel>
 			</layout_stack>
 		</layout_panel>
-		<layout_panel min_width="220" name="media_remote_container" width="220"/>
-		<layout_panel min_width="138" name="voice_remote_container" width="140"/>
+		<layout_panel min_width="240" name="media_remote_container" width="240"/>
+    <!--<layout_panel min_width="138" name="voice_remote_container" width="140"/>-->
+    <layout_panel min_width="138" name="voice_remote_container" width="140"/>
 	</layout_stack>
 </panel>

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -733,7 +733,10 @@ class WindowsManifest(ViewerManifest):
                 self.sign(self.args['dest']+"\\SLVoice.exe")
             except:
                 print ("Couldn't sign binaries. Tried to sign %s" % self.args['dest'] + "\\" + self.final_exe())    
-		
+        else:
+            print("Not creating an installer without a signature");
+            exit();
+            
         # a standard map of strings for replacing in the templates
         substitution_strings = {
             'version' : '.'.join(self.args['version']),


### PR DESCRIPTION

I had trouble bulding Genesis with Python 3.11.4

This is breaking the build for me, it's possibly not a noticeable issue if you already have the template, which has not changed for some years. However on a new build it fails to download the template.

C:\Users\waitm\AppData\Local\Programs\Python\Python311\python.exe C:/Users/waitm/source/repos/Genesis/indra/../scripts/template_verifier.py --mode=development --cache_master --master_url=

issues:


1) optparse was deprecated in 2011, code changed to use argparse instead

2) specifying --master_url= parameter (with no value) does not set it to "none", it sets to "" (empty string). If it doest not show in parameters, then the default is set, if it is empty string then the default is not set. So the code is modified to check for empty string and set it to the default in that case.

3) added more debug output to see what it is doing under the hood.


In indra/newview/viewer_manifest.py, the build was failing if NSIS is not installed (throws windows filenotfound exception despite the try/except block). My quick fix is to skip the whole NSIS build if there is no signature. Really should not be distributing unsigned installers, but maybe there's a better way like adding an NSIS switch/argument, or checking that the regkey exists instead of relying on the try/except failure.


